### PR TITLE
Call SetFileLogging from Core controller instead of WinApp controller

### DIFF
--- a/Core/Controller.cs
+++ b/Core/Controller.cs
@@ -105,9 +105,16 @@ public class Controller
     {
         _configManager.UpdateConfigFromFile();
         _configManager.InvokeConfigUpdatedCallback();
+        SetFileLoggingFromConfig();
         ApplyPollingIntervalFromConfig();
         _fileManager.SetDeleteDelay(_configManager.GetDeleteDelay());
         InitializeProfiles();
+    }
+
+    private void SetFileLoggingFromConfig()
+    {
+        bool logToFile = _configManager.Config.LogToFile;
+        Auxiliary.LogManager.SetFileLogging(logToFile);
     }
 
     private void ApplyPollingIntervalFromConfig()

--- a/WinApp/App/Controller.cs
+++ b/WinApp/App/Controller.cs
@@ -106,9 +106,6 @@ internal class Controller
         if (configInfo.ShowLogConsole.HasValue)
             _consoleManager.SetVisibility(configInfo.ShowLogConsole.Value);
 
-        if (configInfo.LogToFile.HasValue)
-            _coreManager.SetLogToFile(configInfo.LogToFile.Value);
-
         _trayManager.UpdateMenuState(configInfo);
     }
 


### PR DESCRIPTION
Call SetFileLogging from Core controller instead of WinApp controller on config update